### PR TITLE
Update to Rails 5 and use featurer without specific branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-gem 'featurer', github: 'ainformatico/featurer', branch: 'regular_expressions'

--- a/featurer_web.gemspec
+++ b/featurer_web.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
 
-  s.add_dependency 'rails', '~> 4.2.7'
-  s.add_dependency 'featurer'
+  s.add_dependency 'rails', '>= 4.2.7'
+  s.add_dependency 'featurer', '~> 0.1.1'
 end


### PR DESCRIPTION
This PR is 
- allowing to use `featurer_web` with `Rails 5` 
- removing requirement to use `featurer` from `regular_expressions` branch, because it was already merged here:
https://github.com/ainformatico/featurer/commit/c500b14a804084b1bcee5fcf2f94bdeb49e14ef8
